### PR TITLE
Added install whiptail to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ To set up AutoXOA, all you need is a Debian install or variant such as Ubuntu. F
 
 Install curl
 ```
-Apt-get install curl
+apt-get install curl
+```
+
+If you are running this on a minimal install, whiptail also needs to be installed.
+
+```
+apt-get install whiptail
 ```
 
 Run the AutoXOA script
@@ -44,7 +50,7 @@ curl -L DevAutoXOA.zxcv.us | bash
 ### Tasks
 
 #### Stage 1
-- [x] Build a prototype layout. 
+- [x] Build a prototype layout.
 - [x] Gather commands for installation from source.
 - [x] Write curl script to run tasks automatically.
 - [x] Complete autopilot install.


### PR DESCRIPTION
On a minimal install of Debian, whiptail also needs to be installed or the AutoXOA.sh script may fail.

Without this, I was seeing this behaviour. 

```
######################################################
##                                                  ##
##                    Auto XOA                      ##
##                                                  ##
## Deploy Xen Orchestra from source, automatically. ##
##                                                  ##
######################################################
100  5272  100  5272    0     0   5425      0 --:--:-- --:--:-- --:--:--  5425
You are root.
Thank you for using AutoXOA. Leave feedback at zxcv.us or contribute to the Github project.
```

The script would then exit without installing anything.
